### PR TITLE
Website Screen Layout Refinements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       nokogiri
     aws-eventstream (1.0.3)
     aws-partitions (1.272.0)
-    aws-sdk-core (3.89.1)
+    aws-sdk-core (3.90.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)

--- a/config/config.rb
+++ b/config/config.rb
@@ -1,30 +1,10 @@
 # create database qsa_public character set UTF8mb4 collate utf8mb4_bin;
 # grant all on qsa_public.* to 'qsa'@'localhost' identified by 'qsa123';
 
-AppConfig[:db_url] = "jdbc:mysql://localhost:3306/qsa_public?useUnicode=true&characterEncoding=UTF-8&user=sara&password=hannah&serverTimezone=UTC&useSSL=false"
+# AppConfig[:db_url] = "jdbc:mysql://localhost:3306/qsa_public?useUnicode=true&characterEncoding=UTF-8&user=qsa&password=qsa123&serverTimezone=UTC"
 
-AppConfig[:session_secret] = "randomly_generated_token"
+# AppConfig[:session_secret] = "randomly_generated_token"
 
-AppConfig[:minicart_base_url] = 'https://test.smartservice.qld.gov.au'
-AppConfig[:minicart_wsdl] = AppConfig[:minicart_base_url] + '/payment/schemas/shopping_cart_1_3.wsdl'
-AppConfig[:minicart_user] = 'qsa'
-AppConfig[:minicart_password] = 'eyJfI1itiBuZ'
-AppConfig[:minicart_endpoint] = AppConfig[:minicart_base_url] + '/payment/service'
-AppConfig[:minicart_service_name] = "Queensland State Archives"
-AppConfig[:minicart_disbursement_id] = 1
-AppConfig[:minicart_base_order_id] = 0
-
-AppConfig[:minicart_css_url] = "#{AppConfig[:minicart_base_url]}/payment/ui/minicart_1.0.css"
-AppConfig[:minicart_contents_url] = "#{AppConfig[:minicart_base_url]}/payment/minicart/contents_1.0.js"
-AppConfig[:minicart_script_url] = "#{AppConfig[:minicart_base_url]}/payment/ui/minicart_1.0.js"
-
-
-AppConfig[:recaptcha_enabled] = false
-AppConfig[:recaptcha_url] = 'https://www.google.com/recaptcha/api.js'
-AppConfig[:recaptcha_params] = '?onload=captchaOnLoad&render=explicit'
-AppConfig[:recaptcha_verify_url] = 'https://www.google.com/recaptcha/api/siteverify'
-AppConfig[:recaptcha_site_key] = '6LcM2sAUAAAAACqF0u5IqK26jdiCrstC0zI0hTNb'
-AppConfig[:recaptcha_secret_key] = '6LcM2sAUAAAAADuNDvoXCaiy_vWygZ-gD5Iu22JU'
 AppConfig[:indexer_interval_seconds] = 5
 AppConfig[:solr_url] = "http://localhost:9384/solr/qsapublic/"
 AppConfig[:solr_indexer_state_file] = File.join(File.dirname(__FILE__), "..", "data/solr_indexer_state.dat")

--- a/config/config.rb
+++ b/config/config.rb
@@ -1,10 +1,30 @@
 # create database qsa_public character set UTF8mb4 collate utf8mb4_bin;
 # grant all on qsa_public.* to 'qsa'@'localhost' identified by 'qsa123';
 
-# AppConfig[:db_url] = "jdbc:mysql://localhost:3306/qsa_public?useUnicode=true&characterEncoding=UTF-8&user=qsa&password=qsa123&serverTimezone=UTC"
+AppConfig[:db_url] = "jdbc:mysql://localhost:3306/qsa_public?useUnicode=true&characterEncoding=UTF-8&user=sara&password=hannah&serverTimezone=UTC&useSSL=false"
 
-# AppConfig[:session_secret] = "randomly_generated_token"
+AppConfig[:session_secret] = "randomly_generated_token"
 
+AppConfig[:minicart_base_url] = 'https://test.smartservice.qld.gov.au'
+AppConfig[:minicart_wsdl] = AppConfig[:minicart_base_url] + '/payment/schemas/shopping_cart_1_3.wsdl'
+AppConfig[:minicart_user] = 'qsa'
+AppConfig[:minicart_password] = 'eyJfI1itiBuZ'
+AppConfig[:minicart_endpoint] = AppConfig[:minicart_base_url] + '/payment/service'
+AppConfig[:minicart_service_name] = "Queensland State Archives"
+AppConfig[:minicart_disbursement_id] = 1
+AppConfig[:minicart_base_order_id] = 0
+
+AppConfig[:minicart_css_url] = "#{AppConfig[:minicart_base_url]}/payment/ui/minicart_1.0.css"
+AppConfig[:minicart_contents_url] = "#{AppConfig[:minicart_base_url]}/payment/minicart/contents_1.0.js"
+AppConfig[:minicart_script_url] = "#{AppConfig[:minicart_base_url]}/payment/ui/minicart_1.0.js"
+
+
+AppConfig[:recaptcha_enabled] = false
+AppConfig[:recaptcha_url] = 'https://www.google.com/recaptcha/api.js'
+AppConfig[:recaptcha_params] = '?onload=captchaOnLoad&render=explicit'
+AppConfig[:recaptcha_verify_url] = 'https://www.google.com/recaptcha/api/siteverify'
+AppConfig[:recaptcha_site_key] = '6LcM2sAUAAAAACqF0u5IqK26jdiCrstC0zI0hTNb'
+AppConfig[:recaptcha_secret_key] = '6LcM2sAUAAAAADuNDvoXCaiy_vWygZ-gD5Iu22JU'
 AppConfig[:indexer_interval_seconds] = 5
 AppConfig[:solr_url] = "http://localhost:9384/solr/qsapublic/"
 AppConfig[:solr_indexer_state_file] = File.join(File.dirname(__FILE__), "..", "data/solr_indexer_state.dat")

--- a/qsa-public-spa/package-lock.json
+++ b/qsa-public-spa/package-lock.json
@@ -6357,12 +6357,12 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       }
     },
@@ -7102,12 +7102,9 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -8877,9 +8874,9 @@
       }
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -9802,9 +9799,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -9813,7 +9810,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",

--- a/qsa-public-spa/package.json
+++ b/qsa-public-spa/package.json
@@ -14,7 +14,7 @@
     "@types/react-dom": "^16.9.1",
     "@types/react-router-dom": "^4.3.5",
     "axios": "^0.19.0",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.1",
     "query-string": "6.8.3",
     "quill": "^1.3.7",
     "rc-slider": "^8.7.1",

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -214,9 +214,9 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   );
                 })}
               </ul>
-              {agency.getArray('mandate_relationships').length > 0 && <h3>Related mandates</h3>}
+              {agency.getArray('function_relationships').length > 0 && <h3>Related functions</h3>}
               <ul className="list-group list-group-flush">
-                {agency.getArray('mandate_relationships').map((rlshp: any, idx: number) => {
+                {agency.getArray('function_relationships').map((rlshp: any, idx: number) => {
                   return (
                     <li key={idx} className="list-group-item">
                       {<Relationship relationship={rlshp} />}
@@ -224,9 +224,9 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   );
                 })}
               </ul>
-              {agency.getArray('function_relationships').length > 0 && <h3>Related functions</h3>}
+              {agency.getArray('mandate_relationships').length > 0 && <h3>Related mandates</h3>}
               <ul className="list-group list-group-flush">
-                {agency.getArray('function_relationships').map((rlshp: any, idx: number) => {
+                {agency.getArray('mandate_relationships').map((rlshp: any, idx: number) => {
                   return (
                     <li key={idx} className="list-group-item">
                       {<Relationship relationship={rlshp} />}

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -133,8 +133,16 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                 </AccordionPanel>
               ))}
 
-              {agency.getNotes('information_sources', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Information Sources">
+              {agency.getExternalDocuments(['Helpful Resources'], (docs: any) => (
+                <AccordionPanel id={agency.generateId()} title="Helpful Resources">
+                  {docs.map((doc: any) => (
+                      <div><MaybeLink location={doc.location} label={doc.location} /></div>
+                  ))}
+                </AccordionPanel>
+              ))}
+
+              {agency.getNotes('remarks', null, (notes: Note[]) => (
+                <AccordionPanel id={agency.generateId()} title="Notes - Remarks">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -143,14 +151,6 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
 
               {agency.getNotes('preferred_citation', null, (notes: Note[]) => (
                 <AccordionPanel id={agency.generateId()} title="Citation">
-                  {notes.map((note: Note) => (
-                    <NoteDisplay note={note} />
-                  ))}
-                </AccordionPanel>
-              ))}
-
-              {agency.getNotes('remarks', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Remarks">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -181,13 +181,14 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                 </AccordionPanel>
               ))}
 
-              {agency.getExternalDocuments(['Helpful Resources'], (docs: any) => (
-                <AccordionPanel id={agency.generateId()} title="Helpful Resources">
-                  {docs.map((doc: any) => (
-                      <div><MaybeLink location={doc.location} label={doc.location} /></div>
+              {agency.getNotes('information_sources', null, (notes: Note[]) => (
+                <AccordionPanel id={agency.generateId()} title="Notes - Information Sources">
+                  {notes.map((note: Note) => (
+                    <NoteDisplay note={note} />
                   ))}
                 </AccordionPanel>
               ))}
+
             </section>
 
             <section>

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -126,7 +126,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               </ul>
 
               {agency.getNotes('description', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Description">
+                <AccordionPanel id={agency.generateId()} title="Description">
                   {notes.map((note: Note, noteIndex: number) => (
                     <NoteDisplay key={noteIndex} note={note} />
                   ))}
@@ -142,7 +142,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               ))}
 
               {agency.getNotes('remarks', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Remarks">
+                <AccordionPanel id={agency.generateId()} title="Remarks">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -158,7 +158,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               ))}
 
               {agency.getNotes('legislation_establish', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Legislation Establishing">
+                <AccordionPanel id={agency.generateId()} title="Legislation Establishing">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -166,7 +166,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               ))}
 
               {agency.getNotes('legislation_abolish', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Legislation Abolishing">
+                <AccordionPanel id={agency.generateId()} title="Legislation Abolishing">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -174,7 +174,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               ))}
 
               {agency.getNotes('legislation_administered', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Legislation Administering">
+                <AccordionPanel id={agency.generateId()} title="Legislation Administering">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}
@@ -182,7 +182,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
               ))}
 
               {agency.getNotes('information_sources', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Notes - Information Sources">
+                <AccordionPanel id={agency.generateId()} title="Information Sources">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -141,14 +141,6 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                 </AccordionPanel>
               ))}
 
-              {agency.getNotes('information_sources', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Information Sources">
-                  {notes.map((note: Note) => (
-                    <NoteDisplay note={note} />
-                  ))}
-                </AccordionPanel>
-              ))}
-
               {agency.getNotes('remarks', null, (notes: Note[]) => (
                 <AccordionPanel id={agency.generateId()} title="Remarks">
                   {notes.map((note: Note) => (
@@ -183,6 +175,14 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
 
               {agency.getNotes('legislation_administered', null, (notes: Note[]) => (
                 <AccordionPanel id={agency.generateId()} title="Legislation Administering">
+                  {notes.map((note: Note) => (
+                    <NoteDisplay note={note} />
+                  ))}
+                </AccordionPanel>
+              ))}
+
+              {agency.getNotes('information_sources', null, (notes: Note[]) => (
+                <AccordionPanel id={agency.generateId()} title="Information Sources">
                   {notes.map((note: Note) => (
                     <NoteDisplay note={note} />
                   ))}

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -117,7 +117,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   return (
                       <li className="list-group-item list-group-item-action">
                         <div className="d-flex w-100 justify-content-between">
-                          <h4 className="mb-1">Agency Category</h4>
+                          <h4 className="mb-1">Category</h4>
                         </div>
                         <p className="mb-1">{agency.get('agency_category_label') || agency.get('agency_category')}</p>
                       </li>
@@ -137,6 +137,14 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                 <AccordionPanel id={agency.generateId()} title="Helpful Resources">
                   {docs.map((doc: any) => (
                       <div><MaybeLink location={doc.location} label={doc.location} /></div>
+                  ))}
+                </AccordionPanel>
+              ))}
+
+              {agency.getNotes('information_sources', null, (notes: Note[]) => (
+                <AccordionPanel id={agency.generateId()} title="Information Sources">
+                  {notes.map((note: Note) => (
+                    <NoteDisplay note={note} />
                   ))}
                 </AccordionPanel>
               ))}
@@ -181,14 +189,6 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                 </AccordionPanel>
               ))}
 
-              {agency.getNotes('information_sources', null, (notes: Note[]) => (
-                <AccordionPanel id={agency.generateId()} title="Information Sources">
-                  {notes.map((note: Note) => (
-                    <NoteDisplay note={note} />
-                  ))}
-                </AccordionPanel>
-              ))}
-
             </section>
 
             <section>
@@ -214,9 +214,9 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   );
                 })}
               </ul>
-              {agency.getArray('function_relationships').length > 0 && <h3>Related functions</h3>}
+              {agency.getArray('mandate_relationships').length > 0 && <h3>Related mandates</h3>}
               <ul className="list-group list-group-flush">
-                {agency.getArray('function_relationships').map((rlshp: any, idx: number) => {
+                {agency.getArray('mandate_relationships').map((rlshp: any, idx: number) => {
                   return (
                     <li key={idx} className="list-group-item">
                       {<Relationship relationship={rlshp} />}
@@ -224,9 +224,9 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   );
                 })}
               </ul>
-              {agency.getArray('mandate_relationships').length > 0 && <h3>Related mandates</h3>}
+              {agency.getArray('function_relationships').length > 0 && <h3>Related functions</h3>}
               <ul className="list-group list-group-flush">
-                {agency.getArray('mandate_relationships').map((rlshp: any, idx: number) => {
+                {agency.getArray('function_relationships').map((rlshp: any, idx: number) => {
                   return (
                     <li key={idx} className="list-group-item">
                       {<Relationship relationship={rlshp} />}

--- a/qsa-public-spa/src/recordViews/Agency.tsx
+++ b/qsa-public-spa/src/recordViews/Agency.tsx
@@ -117,7 +117,7 @@ const AgencyPage: React.FC<PageRoute> = (route: PageRoute) => {
                   return (
                       <li className="list-group-item list-group-item-action">
                         <div className="d-flex w-100 justify-content-between">
-                          <h4 className="mb-1">Category</h4>
+                          <h4 className="mb-1">Agency Category</h4>
                         </div>
                         <p className="mb-1">{agency.get('agency_category_label') || agency.get('agency_category')}</p>
                       </li>

--- a/qsa-public-spa/src/recordViews/Helpers.tsx
+++ b/qsa-public-spa/src/recordViews/Helpers.tsx
@@ -77,7 +77,7 @@ export const Relationship: React.FC<{ relationship: any }> = ({ relationship }) 
         {relationship._resolved.display_string}
       </Link>
       <br />
-      {rewriteISODates(relationship.start_date)}&nbsp;-&nbsp;{rewriteISODates(relationship.end_date)}
+      {rewriteISODates(relationship.start_date)}&nbsp; to &nbsp;{rewriteISODates(relationship.end_date)}
     </>
   );
 };

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -252,7 +252,7 @@ const DigitalRepresentation: React.FC<{
 
         {representation.getMaybe('intended_use', (value: string) => (
             <>
-              <dt>Intended use</dt>
+              <dt>Intended Use</dt>
               <dd>{value}</dd>
             </>
         ))}
@@ -273,7 +273,7 @@ const DigitalRepresentation: React.FC<{
 
         {representation.getMaybe('preferred_citation', (value: string) => (
             <>
-              <dt>Preferred Citation</dt>
+              <dt>Citation</dt>
               <dd>{value}</dd>
             </>
         ))}
@@ -661,9 +661,6 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
      
             <section className="core-information">
               <h2 className="sr-only">Basic information</h2>
-
-              <p className="lead" style={{whiteSpace: 'pre'}}>{item.get('description')}</p>
-
               <ul className="list-group list-group-horizontal-md">
                 <li className="list-group-item">
                   <span className="small">ID</span>
@@ -729,7 +726,6 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                     </li>
                   );
                 })}
-                {/* Come back and check needs to interact */}
                 {item.getMaybe('description', (value: any) => {
                   return (
                       <li className="list-group-item list-group-item-action">

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -632,59 +632,12 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
               <h3 className="sr-only">Item descriptive metadata</h3>
 
               <ul className="list-group list-group-flush">
-                {item.getMaybe('agency_assigned_id', (value: any) => {
+
+              {item.getMaybe('rap_applied', (rap: any) => {
                   return (
                     <li className="list-group-item list-group-item-action">
                       <div className="d-flex w-100 justify-content-between">
-                        <h4 className="mb-1">Agency Control Number</h4>
-                      </div>
-                      <p className="mb-1">{value}</p>
-                    </li>
-                  );
-                })}
-                {
-                  item.getArray('previous_system_ids').length > 0 &&
-                    <li className="list-group-item list-group-item-action">
-                      <div className="d-flex w-100 justify-content-between">
-                        <h4 className="mb-1">Previous system identifiers</h4>
-                      </div>
-                      <p className="mb-1">{item.getArray('previous_system_ids').join('; ')}</p>
-                    </li>
-                }
-                {
-                  item.getArray('subjects').length > 0 &&
-                  <li className="list-group-item list-group-item-action">
-                    <div className="d-flex w-100 justify-content-between">
-                      <h4 className="mb-1">Subjects</h4>
-                    </div>
-                    <p className="mb-1">{item.getArray('subjects').join('; ')}</p>
-                  </li>
-                }
-                {item.getMaybe('sensitivity_label', (value: any) => {
-                  return (
-                      <li className="list-group-item list-group-item-action">
-                        <div className="d-flex w-100 justify-content-between">
-                          <h4 className="mb-1">Sensitivity Label</h4>
-                        </div>
-                        <p className="mb-1">{value}</p>
-                      </li>
-                  );
-                })}
-                {item.getMaybe('copyright_status', (value: any) => {
-                  return (
-                      <li className="list-group-item list-group-item-action">
-                        <div className="d-flex w-100 justify-content-between">
-                          <h4 className="mb-1">Copyright Status</h4>
-                        </div>
-                        <p className="mb-1">{value}</p>
-                      </li>
-                  );
-                })}
-                {item.getMaybe('rap_applied', (rap: any) => {
-                  return (
-                    <li className="list-group-item list-group-item-action">
-                      <div className="d-flex w-100 justify-content-between">
-                        <h4 className="mb-1">Access status <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></h4>
+                        <h4 className="mb-1">Access Status Summary <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></h4>
                       </div>
                       <div className="mb-1">
                         {
@@ -707,9 +660,70 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                     </li>
                   );
                 })}
+
+                {
+                  item.getArray('previous_system_ids').length > 0 &&
+                    <li className="list-group-item list-group-item-action">
+                      <div className="d-flex w-100 justify-content-between">
+                        <h4 className="mb-1">Previous System Identifiers</h4>
+                      </div>
+                      <p className="mb-1">{item.getArray('previous_system_ids').join('; ')}</p>
+                    </li>
+                }
+
+                {item.getMaybe('agency_assigned_id', (value: any) => {
+                  return (
+                    <li className="list-group-item list-group-item-action">
+                      <div className="d-flex w-100 justify-content-between">
+                        <h4 className="mb-1">Agency Control Number</h4>
+                      </div>
+                      <p className="mb-1">{value}</p>
+                    </li>
+                  );
+                })}
+                {/* Come back and check  */}
+                {item.getMaybe('description', (value: any) => {
+                  return (
+                      <li className="list-group-item list-group-item-action">
+                        <div className="d-flex w-100 justify-content-between">
+                          <h4 className="mb-1">Description</h4>
+                        </div>
+                        <p className="mb-1">{value}</p>
+                      </li>
+                  );
+                })}
+                {
+                  item.getArray('subjects').length > 0 &&
+                  <li className="list-group-item list-group-item-action">
+                    <div className="d-flex w-100 justify-content-between">
+                      <h4 className="mb-1">Subjects</h4>
+                    </div>
+                    <p className="mb-1">{item.getArray('subjects').join('; ')}</p>
+                  </li>
+                }
+                {item.getMaybe('sensitivity_label', (value: any) => {
+                  return (
+                      <li className="list-group-item list-group-item-action">
+                        <div className="d-flex w-100 justify-content-between">
+                          <h4 className="mb-1">Sensitivity Statement</h4>
+                        </div>
+                        <p className="mb-1">{value}</p>
+                      </li>
+                  );
+                })}
+                {item.getMaybe('copyright_status', (value: any) => {
+                  return (
+                      <li className="list-group-item list-group-item-action">
+                        <div className="d-flex w-100 justify-content-between">
+                          <h4 className="mb-1">Copyright Status</h4>
+                        </div>
+                        <p className="mb-1">{value}</p>
+                      </li>
+                  );
+                })}
               </ul>
             </section>
-
+            <Tagger recordId={item.get('id')} context={route.context}/>
             {
               showAccordions &&
               <section className="qg-accordion qg-dark-accordion" aria-label="Item Details">
@@ -720,17 +734,16 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {/*<span className="controls">&#124;</span>*/}
                 {/*<input type="radio" name="control" id="expand" className="controls expand" value="expand" role="radio"/>*/}
                 {/*<label htmlFor="expand" className="controls">Show details</label>*/}
-
-                {item.getNotes('prefercite', null, (notes: Note[]) => (
+                {item.getExternalDocuments(['Helpful Resources'], (docs: any) => (
                     <AccordionPanel
                         id={item.generateId()}
-                        title="Citation"
-                        children={notes.map((note: Note, idx: number) => (
-                            <NoteDisplay key={idx} note={note} />
+                        title="Helpful Resources"
+                        children={docs.map((doc: any, idx: number) => (
+                            <div><MaybeLink location={doc.location} label={doc.location} key={idx} /></div>
                         ))}
                     />
                 ))}
-                {item.getNotes('odd', 'Remarks', (notes: Note[]) => (
+              {item.getNotes('odd', 'Remarks', (notes: Note[]) => (
                     <AccordionPanel
                         id={item.generateId()}
                         title="Notes - Remarks"
@@ -748,15 +761,16 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                         ))}
                     />
                 ))}
-                {item.getExternalDocuments(['Helpful Resources'], (docs: any) => (
+                {item.getNotes('prefercite', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={item.generateId()}
-                        title="Helpful Resources"
-                        children={docs.map((doc: any, idx: number) => (
-                            <div><MaybeLink location={doc.location} label={doc.location} key={idx} /></div>
+                        title="Citation"
+                        children={notes.map((note: Note, idx: number) => (
+                            <NoteDisplay key={idx} note={note} />
                         ))}
                     />
                 ))}
+
                 {item.getArray('physical_representations').length > 0 && (
                     <AccordionPanel
                         id={item.generateId()}
@@ -821,7 +835,6 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
               </section>
             )}
 
-            <Tagger recordId={item.get('id')} context={route.context}/>
           </div>
         </div>
       </Layout>

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -141,6 +141,30 @@ const PhysicalRepresentation: React.FC<{
   );
 };
 
+const DownloadDigitalRepresentation: React.FC<{
+  representation: any;
+}> = ({representation}) => {
+  representation = new RecordDisplay(representation);
+  return (
+    <> {representation.get('representation_file') &&
+          <>
+            <div className="dropdown">
+              <button className="qg-btn btn-warning dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <i className="fa fa-download" aria-hidden="true"></i>
+                Link to download
+                
+            </button>
+              <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
+            <a href={baseURL + '/api/download_file/' + representation.get('qsa_id_prefixed')} target="_blank" rel="noopener noreferrer" className="dropdown-item">
+            </a>
+            </div>
+            </div>
+          </>
+        }
+      </>
+  )
+}
+
 const DigitalRepresentation: React.FC<{
   representation: any;
   item: RecordDisplay;
@@ -405,6 +429,13 @@ const RequestActions: React.FC<any> = ({ item }) => {
       <div className="col-sm-12 record-top-request-buttons">
         <div className={"top-request-button"}><ReadingRoomRequestAction item={item}/></div>
         <div className={"top-request-button"}><DigitalCopyRequestAction item={item}/></div>
+        <div className={"top-request-button"}>
+        {item.getArray('digital_representations').map((representation: any) => (
+                                <div key={representation.qsa_id}>
+                                  <DownloadDigitalRepresentation representation={representation} />
+                                </div>
+                            ))}
+        </div>
       </div>
     </div>
   )

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -628,7 +628,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
             </h1>
 
             <RequestActions item={item} />
-
+     
             <section className="core-information">
               <h2 className="sr-only">Basic information</h2>
 

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -201,7 +201,7 @@ const DigitalRepresentation: React.FC<{
 
         {representation.getArray('previous_system_ids').length > 0 &&
           <>
-            <dt>Previous system identifier</dt>
+            <dt>Previous System Identifier</dt>
             <dd>{representation.getArray('previous_system_ids').join('; ')}</dd>
           </>
         }
@@ -236,7 +236,7 @@ const DigitalRepresentation: React.FC<{
 
         {representation.getMaybe('processing_handling_notes', (value: string) => (
             <>
-              <dt>Processing/handling notes</dt>
+              <dt>Processing/Handling Notes</dt>
               <dd>{value}</dd>
             </>
         ))}
@@ -250,7 +250,7 @@ const DigitalRepresentation: React.FC<{
 
         {representation.getMaybe('preferred_citation', (value: string) => (
             <>
-              <dt>Preferred citation</dt>
+              <dt>Preferred Citation</dt>
               <dd>{value}</dd>
             </>
         ))}

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -730,7 +730,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                   );
                 })}
                 {/* Come back and check needs to interact */}
-                {/* {item.getMaybe('description', (value: any) => {
+                {item.getMaybe('description', (value: any) => {
                   return (
                       <li className="list-group-item list-group-item-action">
                         <div className="d-flex w-100 justify-content-between">
@@ -739,7 +739,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                         <p className="mb-1">{value}</p>
                       </li>
                   );
-                })} */}
+                })}
                 {
                   item.getArray('subjects').length > 0 &&
                   <li className="list-group-item list-group-item-action">

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -764,7 +764,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
               {item.getNotes('odd', 'Remarks', (notes: Note[]) => (
                     <AccordionPanel
                         id={item.generateId()}
-                        title="Notes - Remarks"
+                        title="Remarks"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay key={idx} note={note} />
                         ))}
@@ -773,7 +773,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {item.getNotes('remarks', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={item.generateId()}
-                        title="Notes - Remarks"
+                        title="Remarks"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay key={idx} note={note} />
                         ))}

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -151,11 +151,10 @@ const DownloadDigitalRepresentation: React.FC<{
             <div className="dropdown">
               <button className="qg-btn btn-warning dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i className="fa fa-download" aria-hidden="true"></i>
-                Link to download
-                
+                View Copy
             </button>
               <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
-            <a href={baseURL + '/api/download_file/' + representation.get('qsa_id_prefixed')} target="_blank" rel="noopener noreferrer" className="dropdown-item">
+            <a href={baseURL + '/api/download_file/' + representation.get('qsa_id_prefixed')} target="_blank" rel="noopener noreferrer" className="dropdown-item">Download
             </a>
             </div>
             </div>

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -159,10 +159,10 @@ const DigitalRepresentation: React.FC<{
         {
           representation.get('representation_file') &&
           <>
-            <dt>Download link</dt>
+            <dt>Download File</dt>
             <dd>
             <a href={baseURL + '/api/download_file/' + representation.get('qsa_id_prefixed')} target="_blank" rel="noopener noreferrer">
-            Link to file
+            Link to download
             </a>
             </dd>
           </>
@@ -171,58 +171,10 @@ const DigitalRepresentation: React.FC<{
         <dd>{representation.get('qsa_id_prefixed')}</dd>
         <dt>Title</dt>
         <dd>{representation.get('title')}</dd>
-        {representation.getMaybe('description', (value: string) => (
-            <>
-              <dt>Description</dt>
-              <dd style={{whiteSpace: 'pre'}}>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('file_type', (value: string) => (
-          <>
-            <dt>Format</dt>
-            <dd>{value}</dd>
-          </>
-        ))}
-        {representation.getMaybe('intended_use', (value: string) => (
-            <>
-              <dt>Intended use</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('agency_assigned_id', (value: string) => (
-          <>
-            <dt>Agency ID</dt>
-            <dd>{value}</dd>
-          </>
-        ))}
-        {
-          representation.getArray('previous_system_ids').length > 0 &&
-          <>
-            <dt>Previous system identifier</dt>
-            <dd>{representation.getArray('previous_system_ids').join('; ')}</dd>
-          </>
-        }
-        {representation.getMaybe('preferred_citation', (value: string) => (
-            <>
-              <dt>Preferred citation</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('remarks', (value: string) => (
-            <>
-              <dt>Remarks</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('processing_handling_notes', (value: string) => (
-            <>
-              <dt>Processing/handling notes</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
+
         <dt>Access status <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></dt>
-        {
-          representation.get('rap_access_status') === 'Open Access' ?
+        
+        {representation.get('rap_access_status') === 'Open Access' ?
             <dd className="text-success">Open</dd> :
             <>
               <dd className="text-danger">Restricted</dd>
@@ -237,6 +189,63 @@ const DigitalRepresentation: React.FC<{
               </dd>
             </>
         }
+
+        {representation.getArray('previous_system_ids').length > 0 &&
+          <>
+            <dt>Previous system identifier</dt>
+            <dd>{representation.getArray('previous_system_ids').join('; ')}</dd>
+          </>
+        }
+
+        {representation.getMaybe('agency_assigned_id', (value: string) => (
+          <>
+            <dt>Agency Control Number</dt>
+            <dd>{value}</dd>
+          </>
+        ))}
+       
+        {representation.getMaybe('description', (value: string) => (
+            <>
+              <dt>Description</dt>
+              <dd style={{whiteSpace: 'pre'}}>{value}</dd>
+            </>
+        ))}
+        
+        {representation.getMaybe('file_type', (value: string) => (
+          <>
+            <dt>Format</dt>
+            <dd>{value}</dd>
+          </>
+        ))}
+
+        {representation.getMaybe('intended_use', (value: string) => (
+            <>
+              <dt>Intended use</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+
+        {representation.getMaybe('processing_handling_notes', (value: string) => (
+            <>
+              <dt>Processing/handling notes</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+
+        {representation.getMaybe('remarks', (value: string) => (
+            <>
+              <dt>Remarks</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+
+        {representation.getMaybe('preferred_citation', (value: string) => (
+            <>
+              <dt>Preferred citation</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+
       </dl>
     </>
   );
@@ -681,8 +690,8 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                     </li>
                   );
                 })}
-                {/* Come back and check  */}
-                {item.getMaybe('description', (value: any) => {
+                {/* Come back and check needs to interact */}
+                {/* {item.getMaybe('description', (value: any) => {
                   return (
                       <li className="list-group-item list-group-item-action">
                         <div className="d-flex w-100 justify-content-between">
@@ -691,7 +700,7 @@ const ItemPage: React.FC<PageRoute> = (route: PageRoute) => {
                         <p className="mb-1">{value}</p>
                       </li>
                   );
-                })}
+                })} */}
                 {
                   item.getArray('subjects').length > 0 &&
                   <li className="list-group-item list-group-item-action">

--- a/qsa-public-spa/src/recordViews/Item.tsx
+++ b/qsa-public-spa/src/recordViews/Item.tsx
@@ -61,55 +61,7 @@ const PhysicalRepresentation: React.FC<{
         <dd>{representation.get('qsa_id_prefixed')}</dd>
         <dt>Title</dt>
         <dd>{representation.get('title')}</dd>
-        {representation.getMaybe('description', (value: string) => (
-            <>
-              <dt>Description</dt>
-              <dd style={{whiteSpace: 'pre'}}>{value}</dd>
-            </>
-        ))}
-        <dt>Format</dt>
-        <dd>{representation.get('format')}</dd>
-        {representation.getMaybe('intended_use', (value: string) => (
-            <>
-              <dt>Intended use</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        <dt>Availability</dt>
-        <dd>
-          <span className={`badge badge-pill ${classForAvailability(representation.get('availability'))}`}>{labelForAvailability(representation.get('availability'))}</span>
-        </dd>
-        {representation.getMaybe('agency_assigned_id', (value: string) => (
-          <>
-            <dt>Agency Control Number</dt>
-            <dd>{value}</dd>
-          </>
-        ))}
-        {
-          representation.getArray('previous_system_ids').length > 0 &&
-          <>
-            <dt>Previous system identifier</dt>
-            <dd>{representation.getArray('previous_system_ids').join('; ')}</dd>
-          </>
-        }
-        {representation.getMaybe('preferred_citation', (value: string) => (
-            <>
-              <dt>Citation</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('remarks', (value: string) => (
-            <>
-              <dt>Remarks</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
-        {representation.getMaybe('processing_handling_notes', (value: string) => (
-            <>
-              <dt>Processing/handling notes</dt>
-              <dd>{value}</dd>
-            </>
-        ))}
+
         <dt>Access status <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></dt>
         {
           representation.get('rap_access_status') === 'Open Access' ?
@@ -127,6 +79,63 @@ const PhysicalRepresentation: React.FC<{
               </dd>
             </>
         }
+
+        <dt>Availability</dt>
+        <dd>
+          <span className={`badge badge-pill ${classForAvailability(representation.get('availability'))}`}>{labelForAvailability(representation.get('availability'))}</span>
+        </dd>
+
+        {representation.getArray('previous_system_ids').length > 0 &&
+          <>
+            <dt>Previous System Identifier</dt>
+            <dd>{representation.getArray('previous_system_ids').join('; ')}</dd>
+          </>
+        }
+
+        {representation.getMaybe('agency_assigned_id', (value: string) => (
+          <>
+            <dt>Agency Control Number</dt>
+            <dd>{value}</dd>
+          </>
+        ))}
+
+        {representation.getMaybe('description', (value: string) => (
+            <>
+              <dt>Description</dt>
+              <dd style={{whiteSpace: 'pre'}}>{value}</dd>
+            </>
+        ))}
+
+        <dt>Format</dt>
+        <dd>{representation.get('format')}</dd>
+        {representation.getMaybe('intended_use', (value: string) => (
+            <>
+              <dt>Intended Use</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+
+        {representation.getMaybe('processing_handling_notes', (value: string) => (
+            <>
+              <dt>Processing/Handling Notes</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+        
+        {representation.getMaybe('remarks', (value: string) => (
+            <>
+              <dt>Remarks</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+       
+        {representation.getMaybe('preferred_citation', (value: string) => (
+            <>
+              <dt>Citation</dt>
+              <dd>{value}</dd>
+            </>
+        ))}
+       
       </dl>
     </>
   );

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -154,22 +154,24 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {/*<input type="radio" name="control" id="expand" className="controls expand" value="expand" role="radio"/>*/}
                 {/*<label htmlFor="expand" className="controls">Show details</label>*/}
 
-                {series.getNotes('preferred_citation', null, (notes: Note[]) => (
+                {/* Made the Description notes up the top but come back to make sure it's right  */}
+
+                {series.getNotes('description', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Citation"
+                        title="Notes - Description"
                         children={notes.map((note: Note, idx: number) => (
-                            <NoteDisplay key={idx} note={note} />
+                            <NoteDisplay note={note} key={idx} />
                         ))}
                     />
                 ))}
 
-                {series.getNotes('prefercite', null, (notes: Note[]) => (
+                {series.getExternalDocuments(['Helpful Resources'], (docs: any) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Citation"
-                        children={notes.map((note: Note, idx: number) => (
-                            <NoteDisplay key={idx} note={note} />
+                        title="Helpful Resources"
+                        children={docs.map((doc: any, idx: number) => (
+                            <div key="{idx}"><MaybeLink location={doc.location} label={doc.location} /></div>
                         ))}
                     />
                 ))}
@@ -194,10 +196,32 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                     />
                 ))}
 
+                {series.getNotes('preferred_citation', null, (notes: Note[]) => (
+                    <AccordionPanel
+                        id={series.generateId()}
+                        title="Citation"
+                        children={notes.map((note: Note, idx: number) => (
+                            <NoteDisplay key={idx} note={note} />
+                        ))}
+                    />
+                ))}
+
+
+                {series.getNotes('prefercite', null, (notes: Note[]) => (
+                    <AccordionPanel
+                        id={series.generateId()}
+                        title="Citation"
+                        children={notes.map((note: Note, idx: number) => (
+                            <NoteDisplay key={idx} note={note} />
+                        ))}
+                    />
+                ))}
+
+
                 {series.getNotes('custodhist', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - Agency Control Number (aka Department Numbers)"
+                        title="Notes - Agency Control Number"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -224,15 +248,19 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                     />
                 ))}
 
-                {series.getExternalDocuments(['Helpful Resources'], (docs: any) => (
+               
+
+                {series.getNotes('information_sources', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Helpful Resources"
-                        children={docs.map((doc: any, idx: number) => (
-                            <div key="{idx}"><MaybeLink location={doc.location} label={doc.location} /></div>
+                        title="Notes - Information Sources"
+                        children={notes.map((note: Note, idx: number) => (
+                            <NoteDisplay note={note} key={idx} />
                         ))}
                     />
                 ))}
+
+
               </section>
             }
 

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -140,6 +140,8 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 })}
               </ul>
             </section>
+            
+            <Tagger recordId={series.get('id')} context={route.context}/>
 
             {
               showAccordions &&
@@ -282,7 +284,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
               </ul>
             </section>
 
-            <Tagger recordId={series.get('id')} context={route.context}/>
+           
           </div>
         </div>
       </Layout>

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -154,9 +154,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {/*<input type="radio" name="control" id="expand" className="controls expand" value="expand" role="radio"/>*/}
                 {/*<label htmlFor="expand" className="controls">Show details</label>*/}
 
-                {/* Made the Description notes up the top but come back to make sure it's right becuase needs to interact with as_runcorn  */}
-
-                {/* {series.getNotes('description', null, (notes: Note[]) => (
+                {series.getNotes('description', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
                         title="Notes - Description"
@@ -164,7 +162,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                             <NoteDisplay note={note} key={idx} />
                         ))}
                     />
-                ))} */}
+                ))}
 
                 {series.getExternalDocuments(['Helpful Resources'], (docs: any) => (
                     <AccordionPanel
@@ -247,8 +245,6 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                         ))}
                     />
                 ))}
-
-               
 
                 {series.getNotes('information_sources', null, (notes: Note[]) => (
                     <AccordionPanel

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -154,9 +154,9 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {/*<input type="radio" name="control" id="expand" className="controls expand" value="expand" role="radio"/>*/}
                 {/*<label htmlFor="expand" className="controls">Show details</label>*/}
 
-                {/* Made the Description notes up the top but come back to make sure it's right  */}
+                {/* Made the Description notes up the top but come back to make sure it's right becuase needs to interact with as_runcorn  */}
 
-                {series.getNotes('description', null, (notes: Note[]) => (
+                {/* {series.getNotes('description', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
                         title="Notes - Description"
@@ -164,7 +164,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                             <NoteDisplay note={note} key={idx} />
                         ))}
                     />
-                ))}
+                ))} */}
 
                 {series.getExternalDocuments(['Helpful Resources'], (docs: any) => (
                     <AccordionPanel

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -82,13 +82,13 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
             <section className="core-information">
               <h2 className="sr-only">Basic information</h2>
 
-              <div className="lead">
+              {/* <div className="lead">
                 {
                   ['abstract', 'description'].map((field: any) => (
                     <p key={field}>{series.get(field)}</p>
                   ))
                 }
-              </div>
+              </div> */}
 
               <ul className="list-group list-group-horizontal-md">
                 <li className="list-group-item">
@@ -106,11 +106,22 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
               <h3 className="sr-only">Series descriptive metadata</h3>
 
               <ul className="list-group list-group-flush">
+                
+              <li className="list-group-item list-group-item-action">
+                  <div className="d-flex w-100 justify-content-between">
+                    <h4 className="mb-1">Access Status Summary <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></h4>
+                  </div>
+                  <div className="text-success">{(series.get('access_status_summary')['Open Access'] || 0)} Open Items</div>
+                  <div>
+                    <span className="text-danger">{(series.get('access_status_summary')['Restricted Access'] || 0)} Restricted Items</span>&nbsp;
+                    <a href="/pages/how-do-i-order-restricted-records" rel="noopener noreferrer" target="_blank" aria-label="How to order restricted records"><i className="fa fa-question-circle" title="How to order restricted records" /></a>
+                  </div>
+                </li>
                 {[
-                  ['sensitivity_label', 'Sensitivity label'],
+                  ['repository_processing_note', 'Previous System Identifiers'],
+                  ['sensitivity_label', 'Sensitivity Statement'],
                   ['copyright_status', 'Copyright status'],
-                  ['information_sources', 'Information sources'],
-                  ['repository_processing_note', 'Previous identifiers']
+                  // ['information_sources', 'Information sources']
                 ].map(([fieldName, fieldLabel]) => {
                   return series.getMaybe(fieldName, (value: any) => {
                     return (
@@ -127,17 +138,6 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                     );
                   });
                 })}
-
-                <li className="list-group-item list-group-item-action">
-                  <div className="d-flex w-100 justify-content-between">
-                    <h4 className="mb-1">Access Status Summary <a href="/pages/restricted-access" rel="noopener noreferrer" target="_blank" aria-label="Information about restricted access"><i className="fa fa-question-circle" title="Information about restricted access" /></a></h4>
-                  </div>
-                  <div className="text-success">{(series.get('access_status_summary')['Open Access'] || 0)} Open Items</div>
-                  <div>
-                    <span className="text-danger">{(series.get('access_status_summary')['Restricted Access'] || 0)} Restricted Items</span>&nbsp;
-                    <a href="/pages/how-do-i-order-restricted-records" rel="noopener noreferrer" target="_blank" aria-label="How to order restricted records"><i className="fa fa-question-circle" title="How to order restricted records" /></a>
-                  </div>
-                </li>
               </ul>
             </section>
 

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -82,14 +82,6 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
             <section className="core-information">
               <h2 className="sr-only">Basic information</h2>
 
-              {/* <div className="lead">
-                {
-                  ['abstract', 'description'].map((field: any) => (
-                    <p key={field}>{series.get(field)}</p>
-                  ))
-                }
-              </div> */}
-
               <ul className="list-group list-group-horizontal-md">
                 <li className="list-group-item">
                   <span className="small">ID</span>

--- a/qsa-public-spa/src/recordViews/Series.tsx
+++ b/qsa-public-spa/src/recordViews/Series.tsx
@@ -179,7 +179,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('odd', 'Remarks', (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - Remarks"
+                        title="Remarks"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -189,7 +189,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('remarks', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - Remarks"
+                        title="Remarks"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -221,7 +221,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('custodhist', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - Agency Control Number"
+                        title="Agency Control Number"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -231,7 +231,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('system_of_arrangement', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - System of Arrangement"
+                        title="System of Arrangement"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -241,7 +241,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('arrangement', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - System of Arrangement"
+                        title="System of Arrangement"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}
@@ -253,7 +253,7 @@ const SeriesPage: React.FC<PageRoute> = (route: PageRoute) => {
                 {series.getNotes('information_sources', null, (notes: Note[]) => (
                     <AccordionPanel
                         id={series.generateId()}
-                        title="Notes - Information Sources"
+                        title="Information Sources"
                         children={notes.map((note: Note, idx: number) => (
                             <NoteDisplay note={note} key={idx} />
                         ))}

--- a/qsa-public-spa/src/recordViews/Tagger.tsx
+++ b/qsa-public-spa/src/recordViews/Tagger.tsx
@@ -150,7 +150,7 @@ export const Tagger: React.FC<any> = ({ recordId, context }) => {
 
   return (
     <section>
-      <h3>Tags &nbsp; <small><a href="/pages/user-contributions-tagging" rel="noopener noreferrer" target="_blank" aria-label="Information about user contributed tags"><i className="fa fa-question-circle" />&nbsp;More information</a></small></h3>
+      <h2>User Tags &nbsp; <small><a href="/pages/user-contributions-tagging" rel="noopener noreferrer" target="_blank" aria-label="Information about user contributed tags"><i className="fa fa-question-circle" />&nbsp;More information</a></small></h2>
 
       <form onSubmit={(e) => {e.preventDefault(); addTag()}}>
         {


### PR DESCRIPTION
Fixed up the order of notes for agency screen, series screen and item/representation screen. Moved tagger to above notes. Also reordered & relabelled the digital and physical representations.